### PR TITLE
chore(security): Swagger 관련 URL 예외 설정

### DIFF
--- a/src/main/java/com/example/whales/config/SecurityConfig.java
+++ b/src/main/java/com/example/whales/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.example.whales.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .authorizeHttpRequests(authorize -> authorize
+                        // Swagger 관련 URL 예외
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        // 그 외 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .httpBasic().disable();
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
Spring Security 때문에 swagger 접속 시 404 에러가 발생하는 문제를 swagger 관련 URL을 허용하여 해결했습니다.
그 외 URL은 일단 다 인증이 필요하도록 설정했습니다.
서버 실행 후 http://localhost:8080/api/swagger-ui/index.html 로 접속하시면 확인할 수 있습니다.